### PR TITLE
fix install_github line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package provides a set of functions to simulate a game of Blackjack in R. I
 You can install this package from GitHub using the `devtools` package:
 
 ```r
-devtools::install_github("AlexanderHolmes0/BlackJackPack")
+devtools::install_github("AlexanderHolmes0/BlackJackRPack")
 ```
 
 ## Usage


### PR DESCRIPTION
exhibit A

```r
devtools::install_github("AlexanderHolmes0/BlackJackPack")
# Error: Failed to install 'unknown package' from GitHub:
#  HTTP error 404.
#  Not Found
#
#  Did you spell the repo owner (`AlexanderHolmes0`) and repo name (`BlackJackPack`) correctly?
#  - If spelling is correct, check that you have the required permissions to access the repo.
```

exhibit B

```r
devtools::install_github("AlexanderHolmes0/BlackJackRPack")
# Downloading GitHub repo AlexanderHolmes0/BlackJackRPack@HEAD
# ── R CMD build ───────────────────────────────────────────────────────────────
# ✔  checking for file # ‘/private/var/folders/2h/lk98psvs47d7pf2j4k9rq2mm0000gn/T/Rtmpnr6A4B/remotes7b577c93aa8/AlexanderHolmes0-BlackJackRPack-3656375/DESCRIPTION’ ...
# ─  preparing ‘BlackJackPack’:
# ✔  checking DESCRIPTION meta-information ...
# ─  checking for LF line-endings in source and make files and shell scripts
# ─  checking for empty or unneeded directories
# ─  building ‘BlackJackPack_0.0.0.9000.tar.gz’
#  
# * installing *source* package ‘BlackJackPack’ ...
# ** using staged installation
# ** R
# ** byte-compile and prepare package for lazy loading
# ** help
# *** installing help indices
# ** building package indices
# ** testing if installed package can be loaded from temporary location
# ** testing if installed package can be loaded from final location
# ** testing if installed package keeps a record of temporary installation path
# * DONE (BlackJackPack)
```